### PR TITLE
Support certifiate related commands in openbmc-tool

### DIFF
--- a/thalerj/openbmctool.py
+++ b/thalerj/openbmctool.py
@@ -4449,7 +4449,7 @@ def main(argv=None):
          main function for running the command line utility as a sub application
     """
     global toolVersion
-    toolVersion = "1.14"
+    toolVersion = "1.15"
     parser = createCommandParser()
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Modified openbmctool for certificate commands to be compatible with both OP930 and OP940 releases.
Added back certificate delete command as the same is used in OP930.
Following commands are supported for OP930
certificate update
certificate delete

Following commands are supported for OP940
certificate update
certificate delete
certificate list
certificate display
certificate replace
certificate generatecsr

Based on the version of the software running on the system "NotSupported" error will be thrown when command is executed.