### PR TITLE
SW476240: openbmctool: Ignore sensor associations

### DIFF
--- a/thalerj/openbmctool.py
+++ b/thalerj/openbmctool.py
@@ -524,6 +524,14 @@ def sensor(host, args, session):
         for key in sensors:
             senDict = {}
             keyparts = key.split("/")
+
+            # Associations like the following also show up here:
+            # /xyz/openbmc_project/sensors/<type>/<name>/<assoc-name>
+            # Skip them.
+            # Note:  keyparts[0] = '' which is why there are 7 segments.
+            if len(keyparts) > 6:
+                continue
+
             senDict['sensorName'] = keyparts[-1]
             senDict['type'] = keyparts[-2]
             try:
@@ -4377,7 +4385,7 @@ def main(argv=None):
          main function for running the command line utility as a sub application
     """
     global toolVersion
-    toolVersion = "1.14"
+    toolVersion = "1.15"
     parser = createCommandParser()
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
The sensors namespace also has associations in the path now that are used to
point back to the inventory item they represent.  Skip these
associations when printing sensors by checking the number of segments in
the D-Bus path.

Change-Id: I8dd6eb5ceca0e392d76312012e1fe49b4471ff1d
Signed-off-by: Matt Spinler <spinler@us.ibm.com>

Gerrit review at https://gerrit.openbmc-project.xyz/c/openbmc/openbmc-tools/+/25412